### PR TITLE
ロード画面追加

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -79,12 +79,10 @@
     </div>
     <script>
         //ページ読み込み後　DBへ蔵書DBの照会
-        window.onload = function () {
             admin_cheak()
             send("book_cheak")
             console.log("読み込み完了")
-        }
-    </script>
+</script>
 </body>
 
 </html>

--- a/css/header.css
+++ b/css/header.css
@@ -107,3 +107,35 @@ ul>li>button:active {
 #admin_group{
     display: none;
 }
+
+#overlay{ 
+    position: fixed;
+    top: 0;
+    z-index: 100;
+    width: 100%;
+    height:100%;
+    display: none;
+    background: rgba(0,0,0,0.6);
+  }
+  .cv-spinner {
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;  
+  }
+  .spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px #ddd solid;
+    border-top: 4px #2e93e6 solid;
+    border-radius: 50%;
+    animation: sp-anime 0.8s infinite linear;
+  }
+  @keyframes sp-anime {
+    100% { 
+      transform: rotate(360deg); 
+    }
+  }
+  .is-hide{
+    display:none;
+  }

--- a/header.html
+++ b/header.html
@@ -65,8 +65,14 @@
             </div>
         </ul>
         <button id="admin" onclick="toAdmin()"></button>
+
+        <div id="overlay">
+            <div class="cv-spinner">
+              <span class="spinner"></span>
+            </div>
         <script>
             window.onload = function () {
+                $("#overlay").fadeIn(300);
                 if (Cookies.get('Admin')) {
                     document.getElementById("admin_group").style.display = "block"
                     document.getElementById("admin").style.display = "none"

--- a/js/api.js
+++ b/js/api.js
@@ -15,7 +15,9 @@ function send(mode, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10,
         xhr.onreadystatechange = function () {
                 // readyState XMLHttpRequest の状態 4: リクエストが終了して準備が完了
                 // status httpステータス
-                if (xhr.readyState == 4 && xhr.status == 200) {
+                if (xhr.readyState == 2 ){
+                        $("#overlay").fadeIn(300);
+                }else if (xhr.readyState == 4 && xhr.status == 200) {
                         // jsonをオブジェクトに変更
                         jsonObj = JSON.parse(xhr.responseText);
 
@@ -119,7 +121,6 @@ function send(mode, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10,
                                         }
                                 }
 
-                                return
                         } else if(mode=="reserv_cheak"){
                                 userdata = jsonObj[0]
                                 namedata = jsonObj[1]
@@ -133,6 +134,7 @@ function send(mode, key1, key2, key3, key4, key5, key6, key7, key8, key9, key10,
                 } else if (mode == "log") {
                         systems()
                 }
+                $("#overlay").fadeOut(300);
         }
 }
 

--- a/js/google-login.js
+++ b/js/google-login.js
@@ -2,10 +2,14 @@ let loginData,adminData
 
 
 function toAdmin() {
+    $("#overlay").fadeIn(300);
     const adminCheak = admin();
     if (adminCheak) {
         window.location.href = "./admin.html";
-    } else {}
+    } else {
+
+    $("#overlay").fadeOut(300);
+    }
 }
 
 function admin() {


### PR DESCRIPTION
## やったこと

サーバー通信時、ローディング画面を追加

## やらないこと

なし

## できるようになること（ユーザ目線）

ロード中を判別できる

## できなくなること（ユーザ目線）

ロード中は画面操作ができない

## 動作確認

仮で動作確認を行いました。

## その他

もし、画面をロードで進まない場合は
 $("#overlay").fadeOut(300);
で消せます