### PR TITLE
ポップアップ表示実装

### DIFF
--- a/css/book_swal.css
+++ b/css/book_swal.css
@@ -1,0 +1,116 @@
+/* 書籍詳細表示のswal */
+.swal2-container.swal2-center>.bookDetails {
+    width: 60vw !important;
+    height: 80vh !important;
+    display: block !important;
+}
+
+.bookDetails h2.swal2-title {
+    margin-bottom: 30px;
+    height: 30px;
+    background-color: #0000;
+}
+
+.bookDetails #swal2-html-container {
+    height: 75%;
+}
+
+.bookDetails .bookSwalName {
+    margin: 10px auto 45px;
+    width: 100%;
+    height: 5%;
+    position: relative;
+}
+
+.bookDetails .bookSwalName>span {
+    font-size: .8em;
+    width: 100%;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
+    position: absolute;
+}
+
+.bookDetails .bookSwalName>b {
+    font-size: 1.2em;
+    width: 100%;
+    left: 50%;
+    top: 15px;
+    transform: translateX(-50%);
+    position: absolute;
+}
+
+.bookDetails .bookSwalCoverP {
+    height: 55% !important;
+    margin-bottom: 20px;
+}
+
+.bookDetails img.bookSwalCover {
+    height: 100%;
+    width: auto;
+}
+
+.bookDetails .swal2-confirm {
+    background-color: #150971 !important;
+}
+
+/* 予約確認時のswal */
+
+.swal2-container.swal2-center>.finalConfirmation {
+    width: 60vw !important;
+    height: 80vh !important;
+    display: block !important;
+}
+
+.finalConfirmation h2.swal2-title {
+    margin-bottom: 30px;
+    height: 30px;
+    background-color: #0000;
+}
+
+.finalConfirmation #swal2-html-container {
+    height: 75%;
+}
+
+.finalConfirmation .bookSwalName {
+    margin: 10px auto 75px;
+    width: 100%;
+    height: 5%;
+}
+
+.finalConfirmation .bookSwalName>b {
+    font-size: 1.2em;
+    width: 100%;
+}
+
+.finalConfirmation .bookSwalCoverP {
+    height: 65% !important;
+    margin-bottom: 20px;
+}
+
+.finalConfirmation img.bookSwalCover {
+    height: 100%;
+    width: auto;
+}
+
+.finalConfirmation .swal2-confirm {
+    background-color: #150971 !important;
+    height: 45px;
+    width: 90px;
+    border-radius: 10px;
+}
+
+.finalConfirmation .swal2-cancel {
+    height: 45px;
+    width: 90px;
+    border-radius: 10px;
+}
+
+/* 予約操作キャンセル時のswal */
+.canceled .swal2-container.swal2-center>.swal2-popup {
+    width: 60vw;
+    height: 10vh;
+}
+.canceled .swal2-confirm {
+    background-color: #150971 !important;
+}

--- a/css/library.css
+++ b/css/library.css
@@ -54,6 +54,13 @@ h1 {
     cursor: pointer;
 }
 
+.reserve_btn:focus {
+    outline: 3px double #352991;
+    background-color: #150971dd;
+    border-radius: 10px;
+    transition: .2s;
+}
+
 .reserve_btn:hover {
     background-color: #150971dd;
     border-radius: 10px;
@@ -84,4 +91,8 @@ h1 {
     padding: 5px 15px;
     border-radius: 5px;
     cursor: unset;
+}
+
+.reserved:focus,.limit:focus,.standby:focus {
+    outline: none;
 }

--- a/js/library.js
+++ b/js/library.js
@@ -15,6 +15,7 @@ function test(bookDB) {
                 const $n = i*4+j;
                 const $btn = $(`<button id='btn${String($n)}' class='standby' name='${bookDB[$n][21]}' onClick='toReserve(${bookDB[$n][0]},${$n})'>予約不可</button>`) //予約ボタン
                 const $div = $(`<div id='book${String($n)}' class='book ${bookDB[$n][0]}'></div>`) // 各書籍の表紙, タイトル, 著者を記載する要素
+                const $div2 = $(`<div id='bookData${String($n)}' class='bookData' onClick='popup(${String($n)})'></div>`)
                 const $ps = $(`<div class='ps'><div>`)
     
                 const $cover = $(`<img src='${bookDB[$n][17]}' class='coverimg' alt="${bookDB[$n][1]}" oncontextmenu="return false;">`) // 表紙
@@ -22,7 +23,8 @@ function test(bookDB) {
                 const $writer = $(`<p class='writer'>${bookDB[$n][7]}</p>`) // 著者名
     
                 $ps.append($title).append($writer);
-                $div.append($cover).append($ps).append($btn);
+                $div2.append($cover).append($ps)
+                $div.append($div2).append($btn);
                 $row.append($div);
             }
             $("#container").append($row);
@@ -38,7 +40,7 @@ function toReserve(book_num,n) {
     $("#overlay").fadeIn(300);
     if ($(`#btn${String(n)}`).attr('class') == 'reserve_btn'){
         console.log("tore")
-        send("reserve",cheak().sub, book_num, new Date().toLocaleString(),n)
+        res_popup(book_num,n)
     }
 }
 
@@ -65,7 +67,7 @@ function limit () {
     if (userdata < 3) {
         $(`.standby`).removeClass('standby limit').addClass('reserve_btn').text("予約する");
     } else {
-        $(`.reserve_btn`).removeClass('reserve_btn').addClass('limit').text("予約不可");
+        $(`.reserve_btn`).removeClass('reserve_btn').addClass('limit').removeAttr("onClick").text("予約不可");
     }
 }
 
@@ -76,7 +78,7 @@ function mydata(logDB) {
     console.log(book_length,"Blen") 
     for(let i = 0; book_length > i; i ++){
         if (Number($(`#btn${i+1}`).attr("name")) <= 0){
-            $(`#btn${i+1}`).removeClass('standby reserve_btn').addClass('limit').text("予約不可");
+            $(`#btn${i+1}`).removeClass('standby reserve_btn').addClass('limit').removeAttr("onClick").text("予約不可");
         }
         for(let j = 0; logDB.length > j; j ++){
             let dataJ = logDB[j];
@@ -87,4 +89,46 @@ function mydata(logDB) {
         }
     }
     limit();
+}
+
+function popup(n) {
+    // 蔵書データ[n]でsweetalert表示
+    Swal.fire({
+        title: "書籍詳細",
+        html: `<p class='bookSwalName'><b>『${bookDB[n][1]}』</b><span class='ruby'>${bookDB[n][2]}</span><p>
+        <p class='bookSwalCoverP'><img src='${bookDB[n][17]}' class='bookSwalCover'></p>
+        <p class='bookSwalWriter'>著者：${bookDB[n][7]}</p>
+        <p class='bookSwalPage'>${bookDB[n][11]}ページ</p>
+        <p class='bookSwalData'><span class='bookSwalRegistry'>登録数：${bookDB[n][18]}冊</span>｜<span class='bookSwalStock'>貸出可能在庫：${bookDB[n][21]}冊</span></p>`,
+        backdrop: "#0005",
+        customClass: "bookDetails"
+    })
+}
+
+function res_popup(book_num,n) {
+    // 蔵書データ[n]でsweetalert表示
+    // 予約時最終確認
+    Swal.fire({
+        title: "最終確認",
+        html: `<p class='bookSwalName'>${bookDB[n][7]} の<br><b>『${bookDB[n][1]}』</b><br>を予約します。よろしいですか？</p>
+        <p class='bookSwalCoverP'><img src='${bookDB[n][17]}' class='bookSwalCover'>`,
+        showCancelButton : true,
+        cancelButtonText : 'やめる',
+        showLoaderOnConfirm: true,
+        customClass: "finalConfirmation"
+    }).then((result)=>{
+        console.log("then1")
+        if(result.isConfirmed){
+            send("reserve",cheak().sub, book_num, new Date().toLocaleString(),n)
+        } else {
+            console.log("then2")
+            Swal.fire({
+                title: "予約をキャンセルしました",
+                text: "",
+                customClass:"canceled"
+            }).then(()=>{
+                $("#overlay").fadeOut(300);
+            })
+        }
+    })
 }

--- a/library.html
+++ b/library.html
@@ -6,6 +6,7 @@
 
     <!--CSS-->
     <link rel="stylesheet" href="./css/library.css" />
+    <link rel="stylesheet" href="./css/book_swal.css">
 
     <!--外部JS-->
     <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>


### PR DESCRIPTION
## やったこと

* 書籍詳細, 予約確認（予約操作キャンセル）のポップアップ実装
* 蔵書一覧のボタンフォーカス時アウトラインを調整（予約不可, 予約済みのアウトラインを非表示）

## できるようになること（ユーザ目線）

* 書籍の詳細データを確認できる（在庫数, 登録数, ふりがな他）

## 動作確認

* ローカルで確認