### PR TITLE
ポップアップ修正

### DIFF
--- a/css/book_swal.css
+++ b/css/book_swal.css
@@ -5,6 +5,10 @@
     display: block !important;
 }
 
+.bookSwalWriter a{
+    color: inherit;
+}
+
 .bookDetails h2.swal2-title {
     margin-bottom: 30px;
     height: 30px;

--- a/css/book_swal.css
+++ b/css/book_swal.css
@@ -106,6 +106,16 @@
     border-radius: 10px;
 }
 
+.bookSwalViwe{
+    display: flex;
+    justify-content: center;
+}
+
+.bookSwalViwes2{
+    padding: 5px;
+    text-align: left;
+}
+
 /* 予約操作キャンセル時のswal */
 .canceled .swal2-container.swal2-center>.swal2-popup {
     width: 60vw;

--- a/css/header.css
+++ b/css/header.css
@@ -2,6 +2,9 @@
     margin: 0;
     box-sizing: content-box!important;
 }
+img {
+    -webkit-user-drag: none;
+}
 
 header {
     font-size: 18px;

--- a/js/library.js
+++ b/js/library.js
@@ -100,13 +100,19 @@ function popup(n) {
     Swal.fire({
         title: "書籍詳細",
         html: `<p class='bookSwalName'><b>『${bookDB[n][1]}』</b><span class='ruby'>${bookDB[n][2]}</span><p>
-        <p class='bookSwalCoverP'><img src='${bookDB[n][17]}' class='bookSwalCover'></p>
+        <div class='bookSwalViwe'>
+        <div class='bookSwalViwes'>
+        <p class='bookSwalCoverP'><img src='${bookDB[n][17]}' class='bookSwalCover' oncontextmenu="return false;"></p>
         <p class='bookSwalWriter'>著者：${bookDB[n][7]}</p>
         <p class='bookSwalPage'>${bookDB[n][11]}ページ</p>
-        <p class='bookSwalData'><span class='bookSwalRegistry'>登録数：${bookDB[n][18]}冊</span>｜<span class='bookSwalStock'>貸出可能在庫：${bookDB[n][21]}冊</span></p>`,
+        <p class='bookSwalData'><span class='bookSwalRegistry'>登録数：${bookDB[n][18]}冊</span>｜<span class='bookSwalStock'>貸出可能在庫：${bookDB[n][21]}冊</span></p></div></div>`,
         backdrop: "#0005",
+        confirmButtonText : "閉じる",
         customClass: "bookDetails"
     })
+    if(bookDB[n][13] !=='-' && bookDB[n][13]!==""){
+        $(".bookSwalViwe").append(`<div class='bookSwalViwes2'><p><b>書籍紹介</b></p>${bookDB[n][13]}</div>`)
+    }
 }
 
 function res_popup(book_num,n) {

--- a/js/library.js
+++ b/js/library.js
@@ -103,7 +103,7 @@ function popup(n) {
         <div class='bookSwalViwe'>
         <div class='bookSwalViwes'>
         <p class='bookSwalCoverP'><img src='${bookDB[n][17]}' class='bookSwalCover' oncontextmenu="return false;"></p>
-        <p class='bookSwalWriter'>著者：${bookDB[n][7]}</p>
+        <p class='bookSwalWriter'>著者：<a href='https://www.google.com/search?q=${bookDB[n][7]}'>${bookDB[n][7]}</a></p>
         <p class='bookSwalPage'>${bookDB[n][11]}ページ</p>
         <p class='bookSwalData'><span class='bookSwalRegistry'>登録数：${bookDB[n][18]}冊</span>｜<span class='bookSwalStock'>貸出可能在庫：${bookDB[n][21]}冊</span></p></div></div>`,
         backdrop: "#0005",


### PR DESCRIPTION
## やったこと

* ポップアップ詳細時に書籍紹介文があれば表示する
* 画像をDLできないように右クリック禁止ドラック禁止
* 右クリックは本の画像だけ
* ドラックは全てのページの画像

## できるようになること（ユーザ目線）

* 本の紹介文を確認できる

## できなくなること（ユーザ目線）

* 本の画像を右クリック
* 画像をドラック

## 動作確認

* ローカル環境（クローム）

## その他

* 右クリックとドラックはできません